### PR TITLE
fix typo

### DIFF
--- a/app/mailers/inquiry_mailer.rb
+++ b/app/mailers/inquiry_mailer.rb
@@ -131,10 +131,10 @@ Email: #{order.mail}
     EOS
     if order.receipt_enabled == true
       text.concat("\n\n領収書: 要")
-    else
-      text.concat("\n\n領収書: 不要")
       text.concat("\n\n宛名: #{order.receipt_address}")
       text.concat("\n\n但書: #{order.receipt_proviso}")
+    else
+      text.concat("\n\n領収書: 不要")
     end
     unless order.purpose == 'other'
       text.concat("\n\n用途: #{order.purpose}")


### PR DESCRIPTION
Updating 32e74fe..8881991
Fast-forward Please enter the commit message for your changes. Lines starting
Updating 32e74fe..8881991
Fast-forward with 'Updating 32e74fe..8881991
Fast-forward' will be ignored, and an empty message aborts the commit.
Updating 32e74fe..8881991
Fast-forward
Updating 32e74fe..8881991
Fast-forward On branch update-order-page
Updating 32e74fe..8881991
Fast-forward Your branch is ahead of 'origin/update-order-page' by 1 commit.
Updating 32e74fe..8881991
Fast-forward Changes to be committed:
Updating 32e74fe..8881991
Fast-forward
Updating 32e74fe..8881991
Fast-forward    modified:   app/mailers/inquiry_mailer.rb
